### PR TITLE
Generate source-map reference into less-files

### DIFF
--- a/index.js
+++ b/index.js
@@ -52,7 +52,10 @@ module.exports = {
     }).join('\n')
     return less.render(lessSource, {
       paths: config.paths,
-      sourceMap: {},
+      sourceMap: {
+        sourceMapURL: 'main.css.map',
+        outputSourceFiles: true
+      },
       filename: 'customize-bundle.less',
       compress: true
     }).then(function (lessResult) {

--- a/test/main-spec.js
+++ b/test/main-spec.js
@@ -33,9 +33,8 @@ describe('customize-engine-handlebars', function () {
 
     return expect(result).to.eventually.deep.equal({
       less: {
-        'main.css': 'body{color:#f00;font:sans}',
-        // TODO: The source map doesn't look right. Why is there no reference to main.less
-        'main.css.map': '{"version":3,"sources":["test/fixtures/include/lib1.less"],"names":[],"mappings":"AAAA,KACE,UAAA,CACA"}'
+        'main.css': 'body{color:#f00;font:sans}/*# sourceMappingURL=main.css.map */',
+        'main.css.map': '{"version":3,"sources":["test/fixtures/include/lib1.less"],"names":[],"mappings":"AAAA,KACE,UAAA,CACA","sourcesContent":["body {\\n  color: @bgcolor;\\n  font: @font;\\n}"]}'
       }
     })
   })
@@ -58,9 +57,8 @@ describe('customize-engine-handlebars', function () {
 
     return expect(result).to.eventually.deep.equal({
       less: {
-        'main.css': 'body{color:#0a0;font:sans}',
-        // TODO: The source map doesn't look right. Why is there no reference to main.less and main2.less
-        'main.css.map': '{"version":3,"sources":["test/fixtures/include/lib1.less"],"names":[],"mappings":"AAAA,KACE,UAAA,CACA"}'
+        'main.css': 'body{color:#0a0;font:sans}/*# sourceMappingURL=main.css.map */',
+        'main.css.map': '{"version":3,"sources":["test/fixtures/include/lib1.less"],"names":[],"mappings":"AAAA,KACE,UAAA,CACA","sourcesContent":["body {\\n  color: @bgcolor;\\n  font: @font;\\n}"]}'
       }
     })
   })


### PR DESCRIPTION
This change generates less source-maps correctly
so that they are actually used by Chrome.
